### PR TITLE
Fixed navbar

### DIFF
--- a/wp-content/themes/bpr2018/resources/assets/sass/_header.scss
+++ b/wp-content/themes/bpr2018/resources/assets/sass/_header.scss
@@ -153,7 +153,7 @@
     }
   }
 
-  ul#menu-home-1, ul#menu-home {
+  ul.nav.navbar-nav {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
@@ -232,7 +232,7 @@
         }
         & > ul > li > a {
           text-align: right;
-          font-size: 1.6rem;
+          font-size: 1.6rem !important;
           margin-top: 8px;
         }
       }


### PR DESCRIPTION
The reason why the navbar broke on the staging website is because the navbar ids change for some reason when built and deployed. I've reverted the css selectors back to their class variants, and then reapplied an !important tag where I otherwise can't change a font size.