### PR TITLE
Added skip navigation link for screenreaders

### DIFF
--- a/wp-content/themes/bpr2018/resources/templates/layout/head.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/layout/head.tpl.php
@@ -7,6 +7,7 @@
     <?php wp_head(); ?>
   </head>
   <body <?php body_class(); ?>>
+  <a id="skip-nav" class="sr-only" href="#top-of-content"> Skip Navigation </a> <!-- For screenreaders skipping nav -->
     <?php if (get_field('enable_alert', 'option')): ?>
       <header style="background-color:<?php the_field('alert_background_color', 'option');?>">
         <!-- Alert Banner Scripts are written elsewhere -->
@@ -186,3 +187,5 @@
           })
         });
       </script>
+<div id="top-of-content" name="top-of-content"></div>
+


### PR DESCRIPTION
Added an invisible skip navigation link at the top of the header to redirect to the bottom of the header for screen readers.