### PR TITLE
Lazy Loading using Intersection Observer API

### DIFF
--- a/wp-content/themes/bpr2018/resources/assets/sass/_images.scss
+++ b/wp-content/themes/bpr2018/resources/assets/sass/_images.scss
@@ -18,6 +18,11 @@
   margin-left: $spacing-xs;
 }
 
+.lazy {
+  background-image: none !important;
+  background-color: #F1F1FA !important;
+}
+
 // Darkmode
 @media (prefers-color-scheme: light) {
   #dark { display: none; }

--- a/wp-content/themes/bpr2018/resources/assets/sass/_images.scss
+++ b/wp-content/themes/bpr2018/resources/assets/sass/_images.scss
@@ -18,7 +18,7 @@
   margin-left: $spacing-xs;
 }
 
-.lazy {
+.lazy-image {
   background-image: none !important;
   background-color: #F1F1FA !important;
 }

--- a/wp-content/themes/bpr2018/resources/templates/author.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/author.tpl.php
@@ -4,7 +4,7 @@
   <div id="author-header" class="row">
     <div class="col-md-3 col-xs-12">
       <div id="author-avatar-placeholder">
-        <div id="author-avatar" class="lazy" style="background-image:
+        <div id="author-avatar" class="lazy-image" style="background-image:
           url(<?php echo nl2br(get_avatar_url(get_the_author_meta('user_email'), array("size" => 175))); ?>)">
         </div>
       </div>

--- a/wp-content/themes/bpr2018/resources/templates/author.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/author.tpl.php
@@ -4,7 +4,7 @@
   <div id="author-header" class="row">
     <div class="col-md-3 col-xs-12">
       <div id="author-avatar-placeholder">
-        <div id="author-avatar" style="background-image:
+        <div id="author-avatar" class="lazy" style="background-image:
           url(<?php echo nl2br(get_avatar_url(get_the_author_meta('user_email'), array("size" => 175))); ?>)">
         </div>
       </div>

--- a/wp-content/themes/bpr2018/resources/templates/category.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/category.tpl.php
@@ -52,7 +52,7 @@ if (is_single()) {
                   <div class="col-sm-6">
                     <a href="<?php echo esc_url(get_permalink()); ?>">
                       <div
-                        class="img-40"
+                        class="img-40 lazy"
                         style="background-image: url(<?php echo $pic_url; ?>);">
                         <span role="img" aria-label="<?php echo $pic_alt; ?>"> </span>
                       </div>

--- a/wp-content/themes/bpr2018/resources/templates/category.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/category.tpl.php
@@ -52,7 +52,7 @@ if (is_single()) {
                   <div class="col-sm-6">
                     <a href="<?php echo esc_url(get_permalink()); ?>">
                       <div
-                        class="img-40 lazy"
+                        class="img-40 lazy-image"
                         style="background-image: url(<?php echo $pic_url; ?>);">
                         <span role="img" aria-label="<?php echo $pic_alt; ?>"> </span>
                       </div>

--- a/wp-content/themes/bpr2018/resources/templates/front-page.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/front-page.tpl.php
@@ -34,7 +34,7 @@
                     <a href="<?php echo esc_url(get_permalink($id)); ?>">
                       <?php $placeholderLight = get_image_asset('placeholder_dark.jpg'); ?>
                       <div
-                        class="img-40"
+                        class="img-40 lazy"
                         style="background-image: url(<?php echo $pic_url; ?>), url(<?php echo $placeholderLight; ?>);">
                         <span role="img" aria-label="<?php echo $pic_alt; ?>"> </span>
                       </div>

--- a/wp-content/themes/bpr2018/resources/templates/front-page.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/front-page.tpl.php
@@ -34,7 +34,7 @@
                     <a href="<?php echo esc_url(get_permalink($id)); ?>">
                       <?php $placeholderLight = get_image_asset('placeholder_dark.jpg'); ?>
                       <div
-                        class="img-40 lazy"
+                        class="img-40 lazy-image"
                         style="background-image: url(<?php echo $pic_url; ?>), url(<?php echo $placeholderLight; ?>);">
                         <span role="img" aria-label="<?php echo $pic_alt; ?>"> </span>
                       </div>

--- a/wp-content/themes/bpr2018/resources/templates/layout/head.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/layout/head.tpl.php
@@ -156,6 +156,7 @@
             }
           }
         });
+
         // On nav-icon click, displays animation and applies class open to all children.
         $(document).ready(function(){
           $('#nav-icon').click(function(){
@@ -169,6 +170,26 @@
               $(this).toggleClass("open");
             }
           })
+        });
+
+        // Lazy load images using Intersection Observer API
+        document.addEventListener("DOMContentLoaded", function() {
+          var lazyBackgrounds = [].slice.call(document.querySelectorAll(".lazy"));
+
+          if ("IntersectionObserver" in window) {
+            let lazyBackgroundObserver = new IntersectionObserver(function(entries, observer) {
+              entries.forEach(function(entry) {
+                if (entry.isIntersecting) {
+                  entry.target.classList.remove("lazy");
+                  lazyBackgroundObserver.unobserve(entry.target);
+                }
+              });
+            });
+
+            lazyBackgrounds.forEach(function(lazyBackground) {
+              lazyBackgroundObserver.observe(lazyBackground);
+            });
+          }
         });
       </script>
 <div id="top-of-content" name="top-of-content"></div>

--- a/wp-content/themes/bpr2018/resources/templates/layout/head.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/layout/head.tpl.php
@@ -174,16 +174,19 @@
 
         // Lazy load images using Intersection Observer API
         document.addEventListener("DOMContentLoaded", function() {
-          var lazyBackgrounds = [].slice.call(document.querySelectorAll(".lazy"));
+          let lazyBackgrounds = [].slice.call(document.querySelectorAll(".lazy-image"));
 
           if ("IntersectionObserver" in window) {
             let lazyBackgroundObserver = new IntersectionObserver(function(entries, observer) {
               entries.forEach(function(entry) {
                 if (entry.isIntersecting) {
-                  entry.target.classList.remove("lazy");
+                  entry.target.classList.remove("lazy-image");
                   lazyBackgroundObserver.unobserve(entry.target);
                 }
               });
+            }, {
+              root: null,
+              rootMargin: '0px 0px 200px 0px'
             });
 
             lazyBackgrounds.forEach(function(lazyBackground) {

--- a/wp-content/themes/bpr2018/resources/templates/page.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/page.tpl.php
@@ -14,7 +14,7 @@
             if ($pic_url):
             ?>
               <div
-                class="featured-image"
+                class="featured-image lazy"
                 style="background-image: url(<?php echo $pic_url; ?>);">
               </div>
             <?php endif; ?>

--- a/wp-content/themes/bpr2018/resources/templates/page.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/page.tpl.php
@@ -14,7 +14,7 @@
             if ($pic_url):
             ?>
               <div
-                class="featured-image lazy"
+                class="featured-image lazy-image"
                 style="background-image: url(<?php echo $pic_url; ?>);">
               </div>
             <?php endif; ?>

--- a/wp-content/themes/bpr2018/resources/templates/partials/post/col-block-small.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/partials/post/col-block-small.tpl.php
@@ -11,7 +11,7 @@ $pic_title = get_the_title($pic_id);
         <?php $placeholder = get_image_asset('placeholder_dark.jpg'); ?>
         <?php $placeholder_dark = get_image_asset('placeholder_bright.jpg'); ?>
         <div
-          class="img-10"
+          class="img-10 lazy"
           itemprop="image"
           style="background-image: url(<?php echo $pic_url; ?>), url(<?php echo $placeholder; ?>);">
           <span role="img" aria-label="<?php echo $pic_alt; ?>"> </span>

--- a/wp-content/themes/bpr2018/resources/templates/partials/post/col-block-small.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/partials/post/col-block-small.tpl.php
@@ -11,7 +11,7 @@ $pic_title = get_the_title($pic_id);
         <?php $placeholder = get_image_asset('placeholder_dark.jpg'); ?>
         <?php $placeholder_dark = get_image_asset('placeholder_bright.jpg'); ?>
         <div
-          class="img-10 lazy"
+          class="img-10 lazy-image"
           itemprop="image"
           style="background-image: url(<?php echo $pic_url; ?>), url(<?php echo $placeholder; ?>);">
           <span role="img" aria-label="<?php echo $pic_alt; ?>"> </span>

--- a/wp-content/themes/bpr2018/resources/templates/partials/post/col-block.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/partials/post/col-block.tpl.php
@@ -10,7 +10,7 @@ $pic_title = get_the_title($pic_id);
     <?php $placeholder = get_image_asset('placeholder_dark.jpg'); ?>
       <?php $placeholder_dark = get_image_asset('placeholder_bright.jpg'); ?>
       <div
-        class="img-35"
+        class="img-35 lazy"
         itemprop="image"
         style="background-image: url(<?php echo $pic_url; ?>), url(<?php echo $placeholder; ?>);">
         <span role="img" aria-label="<?php echo $pic_alt; ?>"> </span>

--- a/wp-content/themes/bpr2018/resources/templates/partials/post/col-block.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/partials/post/col-block.tpl.php
@@ -10,7 +10,7 @@ $pic_title = get_the_title($pic_id);
     <?php $placeholder = get_image_asset('placeholder_dark.jpg'); ?>
       <?php $placeholder_dark = get_image_asset('placeholder_bright.jpg'); ?>
       <div
-        class="img-35 lazy"
+        class="img-35 lazy-image"
         itemprop="image"
         style="background-image: url(<?php echo $pic_url; ?>), url(<?php echo $placeholder; ?>);">
         <span role="img" aria-label="<?php echo $pic_alt; ?>"> </span>

--- a/wp-content/themes/bpr2018/resources/templates/partials/post/row-block.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/partials/post/row-block.tpl.php
@@ -11,7 +11,7 @@ $pic_title = get_the_title($pic_id);
       <?php $placeholder = get_image_asset('placeholder_dark.jpg'); ?>
       <?php $placeholder_dark = get_image_asset('placeholder_bright.jpg'); ?>
       <div
-        class="img-30 lazy"
+        class="img-30 lazy-image"
         itemprop="image"
         style="background-image: url(<?php echo $pic_url; ?>), url(<?php echo $placeholder; ?>);">
         <span role="img" aria-label="<?php echo $pic_alt; ?>"> </span>

--- a/wp-content/themes/bpr2018/resources/templates/partials/post/row-block.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/partials/post/row-block.tpl.php
@@ -11,7 +11,7 @@ $pic_title = get_the_title($pic_id);
       <?php $placeholder = get_image_asset('placeholder_dark.jpg'); ?>
       <?php $placeholder_dark = get_image_asset('placeholder_bright.jpg'); ?>
       <div
-        class="img-30"
+        class="img-30 lazy"
         itemprop="image"
         style="background-image: url(<?php echo $pic_url; ?>), url(<?php echo $placeholder; ?>);">
         <span role="img" aria-label="<?php echo $pic_alt; ?>"> </span>

--- a/wp-content/themes/bpr2018/resources/templates/partials/post/row.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/partials/post/row.tpl.php
@@ -49,7 +49,7 @@ $pic_title = get_the_title($pic_id);
       <div class="img-10-wrapper">
         <?php $placeholder = get_image_asset('placeholder_dark.jpg'); ?>
         <div
-          class="img-10 lazy"
+          class="img-10 lazy-image"
           itemprop="image"
           style="background-image: url(<?php echo $pic_url; ?>), url(<?php echo $placeholder; ?>);">
           <span role="img" aria-label="<?php echo $pic_alt; ?>"> </span>
@@ -66,7 +66,7 @@ $pic_title = get_the_title($pic_id);
       <div class="img-10-wrapper">
         <?php $placeholder = get_image_asset('placeholder_dark.jpg'); ?>
         <div
-          class="img-10 lazy"
+          class="img-10 lazy-image"
           itemprop="image"
           style="background-image: url(<?php echo $pic_url; ?>), url(<?php echo $placeholder; ?>);">
           <span role="img" aria-label="<?php echo $pic_alt; ?>"> </span>

--- a/wp-content/themes/bpr2018/resources/templates/partials/post/row.tpl.php
+++ b/wp-content/themes/bpr2018/resources/templates/partials/post/row.tpl.php
@@ -49,7 +49,7 @@ $pic_title = get_the_title($pic_id);
       <div class="img-10-wrapper">
         <?php $placeholder = get_image_asset('placeholder_dark.jpg'); ?>
         <div
-          class="img-10"
+          class="img-10 lazy"
           itemprop="image"
           style="background-image: url(<?php echo $pic_url; ?>), url(<?php echo $placeholder; ?>);">
           <span role="img" aria-label="<?php echo $pic_alt; ?>"> </span>
@@ -66,7 +66,7 @@ $pic_title = get_the_title($pic_id);
       <div class="img-10-wrapper">
         <?php $placeholder = get_image_asset('placeholder_dark.jpg'); ?>
         <div
-          class="img-10"
+          class="img-10 lazy"
           itemprop="image"
           style="background-image: url(<?php echo $pic_url; ?>), url(<?php echo $placeholder; ?>);">
           <span role="img" aria-label="<?php echo $pic_alt; ?>"> </span>


### PR DESCRIPTION
Uses Intersection Observer to lazy load background-image attributes

Notes:
- Not done for any regular `<img>` elements.
- Should probably check if the `!important` tag can be elided, or if there's a better place to put the JS (this should call on all of them, though?)

Fixes #47 